### PR TITLE
add a Date header to the mail

### DIFF
--- a/doc/treasures/active_checks/check_mail_loop
+++ b/doc/treasures/active_checks/check_mail_loop
@@ -329,6 +329,7 @@ def send_mail():
     mail['From']    = mail_from
     mail['To']      = mail_from
     mail['Subject'] = '%s %d %d' % (subject, now, key)
+    mail['Date']    = email.utils.formatdate(localtime=True)
 
     try:
         S = smtplib.SMTP(smtp_server, smtp_port)


### PR DESCRIPTION
amavis is complaining that the generated emails have no date header:
amavis[30926]: (30926-13) Passed BAD-HEADER-7 {RelayedInbound,Quarantined},